### PR TITLE
Add number range query support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.4.0-beta.1]
+
+### Added
+- **Number range queries** with Lucene-style syntax
+- **Numeric comparison operators** (`>`, `<`, `>=`, `<=`)
+- **Range syntax** with `[start TO end]` for numeric fields
+- **Wildcard support** in number ranges (`[* TO end]`, `[start TO *]`)
+- **Decimal number support** for price ranges and precise numeric queries
+- **Complex number queries** combining ranges with logical operators
+
+### Features Implemented
+- `age:[18 TO 65]` - Number range queries using `$gte` and `$lte`
+- `price:[10.50 TO 99.99]` - Decimal number ranges
+- `score:>85` - Greater than comparisons using `$gt`
+- `score:<60` - Less than comparisons using `$lt`
+- `score:>=90` - Greater than or equal using `$gte`
+- `score:<=50` - Less than or equal using `$lte`
+- `age:[18 TO *]` - Open-ended ranges with wildcards
+- `age:[* TO 65]` - Lower-bound ranges with wildcards
+- `age:[18 TO 65] AND status:active` - Number ranges with field conditions
+- `age:>18 OR score:<60` - Multiple numeric comparisons with OR
+- `price:[0 TO 100] OR rating:[4 TO 5]` - Multiple number ranges with OR
+
+### API Changes
+- Enhanced `parseValue()` method to detect and parse number ranges
+- Added `isNumberRange()` and `isNumberComparison()` detection methods
+- Added `parseNumberRange()` and `parseNumberComparison()` parsing methods
+- Improved date detection to distinguish between date and number ranges
+- Enhanced type detection for better numeric vs date parsing
+
+### Documentation
+- Updated README.md with comprehensive number range examples
+- Added number range features to feature list
+- Updated integration tests with real MongoDB number range queries
+- Enhanced examples with number range demonstrations
+
+### Testing
+- Added comprehensive unit tests for number range functionality
+- Added integration tests for invalid number query handling
+- All existing tests continue to pass (no regressions)
+
 ## [v0.3.0-beta.1]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A Go library that provides Lucene-style syntax for MongoDB BSON filters. Convert
 - **Logical operators**: Support for AND, OR, and NOT operations
 - **Grouping logic**: Parentheses support for complex query grouping and precedence control
 - **Date queries**: Full support for date range and comparison queries
+- **Number ranges**: Support for numeric range queries and comparisons
 - **Type-aware parsing**: Automatically detects and parses booleans, numbers, and dates
 - **Full-text search**: Support for MongoDB text search with configurable search modes
 - **MongoDB compatible**: Generates BSON that works with the latest MongoDB Go driver
@@ -199,6 +200,48 @@ query, _ := bsonic.Parse("created_at:[2023-01-01 TO 2023-12-31] AND status:activ
 
 query, _ := bsonic.Parse("created_at:>2024-01-01 OR updated_at:<2023-01-01")
 // BSON: {"$or": [{"created_at": {"$gt": "2024-01-01 00:00:00 +0000 UTC"}}, {"updated_at": {"$lt": "2023-01-01 00:00:00 +0000 UTC"}}]}
+```
+
+### Number Range Queries
+
+```go
+// Number ranges
+query, _ := bsonic.Parse("age:[18 TO 65]")
+// BSON: {"age": {"$gte": 18, "$lte": 65}}
+
+// Decimal number ranges
+query, _ := bsonic.Parse("price:[10.50 TO 99.99]")
+// BSON: {"price": {"$gte": 10.5, "$lte": 99.99}}
+
+// Number ranges with wildcards
+query, _ := bsonic.Parse("age:[18 TO *]")
+// BSON: {"age": {"$gte": 18}}
+
+query, _ := bsonic.Parse("age:[* TO 65]")
+// BSON: {"age": {"$lte": 65}}
+
+// Number comparisons
+query, _ := bsonic.Parse("score:>85")
+// BSON: {"score": {"$gt": 85}}
+
+query, _ := bsonic.Parse("score:<60")
+// BSON: {"score": {"$lt": 60}}
+
+query, _ := bsonic.Parse("score:>=90")
+// BSON: {"score": {"$gte": 90}}
+
+query, _ := bsonic.Parse("score:<=50")
+// BSON: {"score": {"$lte": 50}}
+
+// Complex number queries
+query, _ := bsonic.Parse("age:[18 TO 65] AND status:active")
+// BSON: {"age": {"$gte": 18, "$lte": 65}, "status": "active"}
+
+query, _ := bsonic.Parse("age:>18 OR score:<60")
+// BSON: {"$or": [{"age": {"$gt": 18}}, {"score": {"$lt": 60}}]}
+
+query, _ := bsonic.Parse("price:[0 TO 100] OR rating:[4 TO 5]")
+// BSON: {"$or": [{"price": {"$gte": 0, "$lte": 100}}, {"rating": {"$gte": 4, "$lte": 5}}]}
 ```
 
 ### Supported Date Formats

--- a/examples/integration/main.go
+++ b/examples/integration/main.go
@@ -60,6 +60,15 @@ func main() {
 		"name:John Doe AND role:admin",
 		"name:John Doe OR name:Jane Smith",
 		"active:true AND NOT role:admin",
+		// Number range examples
+		"age:30",
+		"age:[25 TO 35]",
+		"age:>30",
+		"age:<30",
+		"age:>=30",
+		"age:<=30",
+		"age:[25 TO 35] AND active:true",
+		"age:>30 OR role:moderator",
 	}
 
 	fmt.Println("\n🔍 Testing BSON queries against real MongoDB data:")

--- a/examples/main.go
+++ b/examples/main.go
@@ -30,6 +30,17 @@ func main() {
 		"created_at:<=2023-12-31",
 		"created_at:[2023-01-01 TO 2023-12-31] AND status:active",
 		"created_at:>2024-01-01 OR updated_at:<2023-01-01",
+		// Number range examples
+		"age:25",
+		"age:[18 TO 65]",
+		"price:[10.50 TO 99.99]",
+		"score:>85",
+		"score:<60",
+		"score:>=90",
+		"score:<=50",
+		"age:[18 TO 65] AND status:active",
+		"age:>18 OR score:<60",
+		"price:[0 TO 100] OR rating:[4 TO 5]",
 		// Parentheses examples
 		"(name:john OR name:jane) AND age:25",
 		"name:john OR (name:jane AND age:25)",


### PR DESCRIPTION
## Description
- **Number range queries** with Lucene-style syntax
- **Numeric comparison operators** (`>`, `<`, `>=`, `<=`)
- **Range syntax** with `[start TO end]` for numeric fields
- **Wildcard support** in number ranges (`[* TO end]`, `[start TO *]`)
- **Decimal number support** for price ranges and precise numeric queries
- **Complex number queries** combining ranges with logical operators

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
- [x] Tests pass locally
- [x] Manual testing completed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is properly commented
- [x] No linting errors
- [x] Documentation updated (if applicable)
- [x] New unit and integration tests added for new functionality
- [x] All existing tests still pass

## Related Issues
NA

## Additional Notes
NA
